### PR TITLE
convert dashes to underscores in constant names

### DIFF
--- a/constant_cache.gemspec
+++ b/constant_cache.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{constant_cache}
-  s.version = "0.1.2"
+  s.version = "0.1.3"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Patrick Reagan", "Tony Pitale"]

--- a/lib/constant_cache/core_ext.rb
+++ b/lib/constant_cache/core_ext.rb
@@ -8,7 +8,7 @@ class String
   #   'Restaurants & Bars'.constant_name => 'RESTAURANTS_BARS'
   #
   def constant_name
-    value = self.strip.gsub(/\s+/, '_').gsub(/[^\w_]/, '').gsub(/_{2,}/, '_').upcase
+    value = self.strip.gsub(/\s|-+/, '_').gsub(/[^\w_]/, '').gsub(/_{2,}/, '_').upcase
     (value == '') ? nil : value
   end
 

--- a/test/constant_cache/core_ext_test.rb
+++ b/test/constant_cache/core_ext_test.rb
@@ -29,5 +29,10 @@ class CoreExtTest < Test::Unit::TestCase
     should "collapse multiple underscores" do
       'test__me'.constant_name.should == 'TEST_ME'
     end
+
+    should "convert dashes to underscores" do
+      'test-me'.constant_name.should == 'TEST_ME'
+    end
   end
 end
+


### PR DESCRIPTION
Wasn't sure if this should go in the dm branch as well, but I suppose you could cherry pick it across if so.

I added a test but couldn't actually run it without updating a lot of other things, (e.g. the matchy gem doesn't exist anymore that I could find) but tested it manually. 

I also bumped the minor version number but perhaps since this might break functionality others are depending on it should be a larger bump?
